### PR TITLE
removed unnecessary null aware operator for non null able type

### DIFF
--- a/lib/mvvm_builder.widget.dart
+++ b/lib/mvvm_builder.widget.dart
@@ -44,8 +44,8 @@ class _MVVMState<T extends ViewModel> extends State<MVVM<T>> with WidgetsBinding
     super.initState();
     _vm = widget.props.viewModel;
 
-    WidgetsBinding.instance?.addObserver(this);
-    WidgetsBinding.instance?.addPostFrameCallback((_) => _vm.onMount());
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _vm.onMount());
   }
 
   @override
@@ -75,7 +75,7 @@ class _MVVMState<T extends ViewModel> extends State<MVVM<T>> with WidgetsBinding
 
   @override
   void dispose() {
-    WidgetsBinding.instance?.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     _vm.onUnmount();
     super.dispose();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pmvvm
 description: A clean & simple MVVM solution for state management using Provider package.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/NourEldinShobier/pmvvm
 
 environment:


### PR DESCRIPTION
remove unnecessary null aware operator `?.` called on `WidgetsBinding.instance` because now with flutter 3.0 the type is not null able, [see docs](https://api.flutter.dev/flutter/widgets/WidgetsBinding/instance.html)